### PR TITLE
Unify type to String

### DIFF
--- a/lib/mirei.rb
+++ b/lib/mirei.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 module Mirei
   def self.regulation(number)
-    Mirei::Regulation.new(number)
+    Mirei::Regulation.new(number.to_s)
   end
 
   class Regulation


### PR DESCRIPTION
before

```ruby
Mirei.regulation('1234') # => OK
Mirei.regulation(1234)   # => NG (`Mirei::Regulation` is expect `String` object)
```

after

```ruby
Mirei.regulation('1234') # => OK
Mirei.regulation(1234)   # => OK
```